### PR TITLE
Fix markup and improve accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,17 +1,17 @@
-
 <!DOCTYPE html>
 <html lang="es">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Currículum de Félix Arias Robles, profesor de la UMH especializado en innovación y periodismo.">
     <title>Félix Arias Robles</title>
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
     <header>
-        <img src="img/portada.jpg" alt="Félix Arias Robles">
+        <img src="img/portada.jpg" alt="Fotografía de Félix Arias Robles">
         <h1>Félix Arias Robles</h1>
-        <nav>
+        <nav role="navigation">
             <ul>
                 <li><a href="#sobre-mi">Sobre mí</a></li>
                 <li><a href="#docencia">Docencia</a></li>
@@ -22,7 +22,7 @@
             </ul>
         </nav>
     </header>
-    <main>
+    <main role="main">
         <section id="sobre-mi">
             <h2>Sobre mí</h2>
             <p>Profesor Titular de Universidad en el Departamento de Ciencias Sociales y Humanas de la Universidad Miguel Hernández (UMH) de Elche. Vicedecano del Grado en Periodismo y Subdirector del Máster en Innovación en Periodismo. Experiencia en docencia, investigación y gestión en el ámbito de la comunicación, con especialización en innovación, inteligencia artificial y periodismo de datos.</p>
@@ -37,7 +37,7 @@
             <h2>Investigación</h2>
             <p>Líneas principales: innovación en medios, inteligencia artificial y automatización, laboratorios de medios, nuevas rutinas profesionales.<br>
             Proyectos financiados nacionales y europeos (H2020, Erasmus+, etc.).<br>
-            Publicaciones en revistas indexadas como <i>El Profesional de la Información</i>, <i>Media and Communication</i> o <i>Communication & Society</i>.</p>
+            Publicaciones en revistas indexadas como <i>El Profesional de la Información</i>, <i>Media and Communication</i> o <i>Communication &amp; Society</i>.</p>
         </section>
         <section id="transferencia">
             <h2>Transferencia</h2>


### PR DESCRIPTION
## Summary
- fix long-line breaks in HTML paragraphs
- add meta description
- provide clearer `alt` text
- set roles for `nav` and `main`
- escape `&` in cited journal

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684d453268dc8325be2a616b517c0c0a